### PR TITLE
Antenna info module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,4 @@ release/
 .vscode/extensions.json
 /compile_commands.json
 src/mesh/raspihttp/certificate.pem
-src/mesh/raspihttp/private_key.pemsrc/mesh/generated/
-
+src/mesh/raspihttp/private_key.pem

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ release/
 .vscode/extensions.json
 /compile_commands.json
 src/mesh/raspihttp/certificate.pem
-src/mesh/raspihttp/private_key.pem
+src/mesh/raspihttp/private_key.pemsrc/mesh/generated/
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "protobufs"]
 	path = protobufs
-	url = https://github.com/meshtastic/protobufs.git
+	url = git@github.com:ajvpot/meshtastic-protobufs.git
 [submodule "meshtestic"]
 	path = meshtestic
 	url = https://github.com/meshtastic/meshTestic

--- a/platformio.ini
+++ b/platformio.ini
@@ -51,7 +51,6 @@ build_flags = -Wno-missing-field-initializers
 	-DMESHTASTIC_EXCLUDE_HEALTH_TELEMETRY=1
   	-DMESHTASTIC_EXCLUDE_POWERSTRESS=1 ; exclude power stress test module from main firmware
 	-DMESHTASTIC_EXCLUDE_GENERIC_THREAD_MODULE=1
-	-DMESHTASTIC_EXCLUDE_ANTENNAINFO=1 ; exclude antenna info module from main firmware
         #-DBUILD_EPOCH=$UNIX_TIME
         #-D OLED_PL=1
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -51,6 +51,7 @@ build_flags = -Wno-missing-field-initializers
 	-DMESHTASTIC_EXCLUDE_HEALTH_TELEMETRY=1
   	-DMESHTASTIC_EXCLUDE_POWERSTRESS=1 ; exclude power stress test module from main firmware
 	-DMESHTASTIC_EXCLUDE_GENERIC_THREAD_MODULE=1
+	-DMESHTASTIC_EXCLUDE_ANTENNAINFO=1 ; exclude antenna info module from main firmware
         #-DBUILD_EPOCH=$UNIX_TIME
         #-D OLED_PL=1
 

--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -22,7 +22,8 @@
 #define default_antenna_info_broadcast_secs 4 * 60 * 60
 #define min_node_info_broadcast_secs 60 * 60 // No regular broadcasts of more than once an hour
 #define min_neighbor_info_broadcast_secs 4 * 60 * 60
-#define min_antenna_info_broadcast_secs 1 * 60 * 60 // Minimum 1 hour for antenna info
+// #define min_antenna_info_broadcast_secs 1 * 60 * 60 // Minimum 1 hour for antenna info
+#define min_antenna_info_broadcast_secs 0 // Bypass minimum check - allow any interval
 #define default_map_publish_interval_secs 60 * 60
 
 #define default_mqtt_address "mqtt.meshtastic.org"

--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -22,8 +22,7 @@
 #define default_antenna_info_broadcast_secs 4 * 60 * 60
 #define min_node_info_broadcast_secs 60 * 60 // No regular broadcasts of more than once an hour
 #define min_neighbor_info_broadcast_secs 4 * 60 * 60
-// #define min_antenna_info_broadcast_secs 1 * 60 * 60 // Minimum 1 hour for antenna info
-#define min_antenna_info_broadcast_secs 0 // Bypass minimum check - allow any interval
+#define min_antenna_info_broadcast_secs 1 * 60 * 60 // Minimum 1 hour for antenna info
 #define default_map_publish_interval_secs 60 * 60
 
 #define default_mqtt_address "mqtt.meshtastic.org"

--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -19,8 +19,10 @@
 #define default_screen_on_secs IF_ROUTER(1, 60 * 10)
 #define default_node_info_broadcast_secs 3 * 60 * 60
 #define default_neighbor_info_broadcast_secs 6 * 60 * 60
+#define default_antenna_info_broadcast_secs 4 * 60 * 60
 #define min_node_info_broadcast_secs 60 * 60 // No regular broadcasts of more than once an hour
 #define min_neighbor_info_broadcast_secs 4 * 60 * 60
+#define min_antenna_info_broadcast_secs 1 * 60 * 60 // Minimum 1 hour for antenna info
 #define default_map_publish_interval_secs 60 * 60
 
 #define default_mqtt_address "mqtt.meshtastic.org"

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -337,6 +337,10 @@ NodeDB::NodeDB()
     moduleConfig.neighbor_info.update_interval =
         Default::getConfiguredOrMinimumValue(moduleConfig.neighbor_info.update_interval, min_neighbor_info_broadcast_secs);
 
+    // Ensure that the antenna info update interval is coerced to the minimum
+    moduleConfig.antenna_info.update_interval =
+        Default::getConfiguredOrMinimumValue(moduleConfig.antenna_info.update_interval, min_antenna_info_broadcast_secs);
+
     // Don't let licensed users to rebroadcast encrypted packets
     if (owner.is_licensed) {
         config.device.rebroadcast_mode = meshtastic_Config_DeviceConfig_RebroadcastMode_LOCAL_ONLY;
@@ -803,6 +807,9 @@ void NodeDB::installDefaultModuleConfig()
     moduleConfig.has_neighbor_info = true;
     moduleConfig.neighbor_info.enabled = false;
 
+    moduleConfig.has_antenna_info = true;
+    moduleConfig.antenna_info.enabled = false;
+
     moduleConfig.has_detection_sensor = true;
     moduleConfig.detection_sensor.enabled = false;
     moduleConfig.detection_sensor.detection_trigger_type = meshtastic_ModuleConfig_DetectionSensorConfig_TriggerType_LOGIC_HIGH;
@@ -873,6 +880,7 @@ void NodeDB::installRoleDefaults(meshtastic_Config_DeviceConfig_Role role)
         config.position.position_broadcast_smart_enabled = false;
         config.position.position_broadcast_secs = UINT32_MAX;
         moduleConfig.neighbor_info.update_interval = UINT32_MAX;
+        moduleConfig.antenna_info.update_interval = UINT32_MAX;
         moduleConfig.telemetry.device_update_interval = UINT32_MAX;
         moduleConfig.telemetry.environment_update_interval = UINT32_MAX;
         moduleConfig.telemetry.air_quality_interval = UINT32_MAX;
@@ -889,6 +897,7 @@ void NodeDB::initModuleConfigIntervals()
     moduleConfig.telemetry.power_update_interval = 0;
     moduleConfig.telemetry.health_update_interval = 0;
     moduleConfig.neighbor_info.update_interval = 0;
+    moduleConfig.antenna_info.update_interval = 0;
     moduleConfig.paxcounter.paxcounter_update_interval = 0;
 }
 
@@ -1340,6 +1349,7 @@ bool NodeDB::saveToDiskNoRetry(int saveWhat)
         moduleConfig.has_store_forward = true;
         moduleConfig.has_telemetry = true;
         moduleConfig.has_neighbor_info = true;
+        moduleConfig.has_antenna_info = true;
         moduleConfig.has_detection_sensor = true;
         moduleConfig.has_ambient_lighting = true;
         moduleConfig.has_audio = true;

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -338,8 +338,8 @@ NodeDB::NodeDB()
         Default::getConfiguredOrMinimumValue(moduleConfig.neighbor_info.update_interval, min_neighbor_info_broadcast_secs);
 
     // Ensure that the antenna info update interval is coerced to the minimum
-    // moduleConfig.antenna_info.update_interval =
-    //     Default::getConfiguredOrMinimumValue(moduleConfig.antenna_info.update_interval, min_antenna_info_broadcast_secs);
+    moduleConfig.antenna_info.update_interval =
+        Default::getConfiguredOrMinimumValue(moduleConfig.antenna_info.update_interval, min_antenna_info_broadcast_secs);
 
     // Don't let licensed users to rebroadcast encrypted packets
     if (owner.is_licensed) {

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -338,8 +338,8 @@ NodeDB::NodeDB()
         Default::getConfiguredOrMinimumValue(moduleConfig.neighbor_info.update_interval, min_neighbor_info_broadcast_secs);
 
     // Ensure that the antenna info update interval is coerced to the minimum
-    moduleConfig.antenna_info.update_interval =
-        Default::getConfiguredOrMinimumValue(moduleConfig.antenna_info.update_interval, min_antenna_info_broadcast_secs);
+    // moduleConfig.antenna_info.update_interval =
+    //     Default::getConfiguredOrMinimumValue(moduleConfig.antenna_info.update_interval, min_antenna_info_broadcast_secs);
 
     // Don't let licensed users to rebroadcast encrypted packets
     if (owner.is_licensed) {

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -392,6 +392,11 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_paxcounter_tag;
             fromRadioScratch.moduleConfig.payload_variant.paxcounter = moduleConfig.paxcounter;
             break;
+        case meshtastic_ModuleConfig_antenna_info_tag:
+            LOG_DEBUG("Send module config: antenna info");
+            fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_antenna_info_tag;
+            fromRadioScratch.moduleConfig.payload_variant.antenna_info = moduleConfig.antenna_info;
+            break;
         default:
             LOG_ERROR("Unknown module config type %d", config_state);
         }

--- a/src/mesh/generated/meshtastic/admin.pb.h
+++ b/src/mesh/generated/meshtastic/admin.pb.h
@@ -67,7 +67,9 @@ typedef enum _meshtastic_AdminMessage_ModuleConfigType {
     /* TODO: REPLACE */
     meshtastic_AdminMessage_ModuleConfigType_DETECTIONSENSOR_CONFIG = 11,
     /* TODO: REPLACE */
-    meshtastic_AdminMessage_ModuleConfigType_PAXCOUNTER_CONFIG = 12
+    meshtastic_AdminMessage_ModuleConfigType_PAXCOUNTER_CONFIG = 12,
+    /* TODO: REPLACE */
+    meshtastic_AdminMessage_ModuleConfigType_ANTENNAINFO_CONFIG = 13
 } meshtastic_AdminMessage_ModuleConfigType;
 
 typedef enum _meshtastic_AdminMessage_BackupLocation {
@@ -246,8 +248,8 @@ extern "C" {
 #define _meshtastic_AdminMessage_ConfigType_ARRAYSIZE ((meshtastic_AdminMessage_ConfigType)(meshtastic_AdminMessage_ConfigType_DEVICEUI_CONFIG+1))
 
 #define _meshtastic_AdminMessage_ModuleConfigType_MIN meshtastic_AdminMessage_ModuleConfigType_MQTT_CONFIG
-#define _meshtastic_AdminMessage_ModuleConfigType_MAX meshtastic_AdminMessage_ModuleConfigType_PAXCOUNTER_CONFIG
-#define _meshtastic_AdminMessage_ModuleConfigType_ARRAYSIZE ((meshtastic_AdminMessage_ModuleConfigType)(meshtastic_AdminMessage_ModuleConfigType_PAXCOUNTER_CONFIG+1))
+#define _meshtastic_AdminMessage_ModuleConfigType_MAX meshtastic_AdminMessage_ModuleConfigType_ANTENNAINFO_CONFIG
+#define _meshtastic_AdminMessage_ModuleConfigType_ARRAYSIZE ((meshtastic_AdminMessage_ModuleConfigType)(meshtastic_AdminMessage_ModuleConfigType_ANTENNAINFO_CONFIG+1))
 
 #define _meshtastic_AdminMessage_BackupLocation_MIN meshtastic_AdminMessage_BackupLocation_FLASH
 #define _meshtastic_AdminMessage_BackupLocation_MAX meshtastic_AdminMessage_BackupLocation_SD

--- a/src/mesh/generated/meshtastic/deviceonly.pb.h
+++ b/src/mesh/generated/meshtastic/deviceonly.pb.h
@@ -355,7 +355,7 @@ extern const pb_msgdesc_t meshtastic_BackupPreferences_msg;
 /* Maximum encoded size of messages (where known) */
 /* meshtastic_NodeDatabase_size depends on runtime parameters */
 #define MESHTASTIC_MESHTASTIC_DEVICEONLY_PB_H_MAX_SIZE meshtastic_BackupPreferences_size
-#define meshtastic_BackupPreferences_size        2267
+#define meshtastic_BackupPreferences_size        2301
 #define meshtastic_ChannelFile_size              718
 #define meshtastic_DeviceState_size              1722
 #define meshtastic_NodeInfoLite_size             190

--- a/src/mesh/generated/meshtastic/localonly.pb.h
+++ b/src/mesh/generated/meshtastic/localonly.pb.h
@@ -87,6 +87,9 @@ typedef struct _meshtastic_LocalModuleConfig {
     /* Paxcounter Config */
     bool has_paxcounter;
     meshtastic_ModuleConfig_PaxcounterConfig paxcounter;
+    /* The part of the config that is specific to the Antenna Info module */
+    bool has_antenna_info;
+    meshtastic_ModuleConfig_AntennaInfoConfig antenna_info;
 } meshtastic_LocalModuleConfig;
 
 
@@ -96,9 +99,9 @@ extern "C" {
 
 /* Initializer values for message structs */
 #define meshtastic_LocalConfig_init_default      {false, meshtastic_Config_DeviceConfig_init_default, false, meshtastic_Config_PositionConfig_init_default, false, meshtastic_Config_PowerConfig_init_default, false, meshtastic_Config_NetworkConfig_init_default, false, meshtastic_Config_DisplayConfig_init_default, false, meshtastic_Config_LoRaConfig_init_default, false, meshtastic_Config_BluetoothConfig_init_default, 0, false, meshtastic_Config_SecurityConfig_init_default}
-#define meshtastic_LocalModuleConfig_init_default {false, meshtastic_ModuleConfig_MQTTConfig_init_default, false, meshtastic_ModuleConfig_SerialConfig_init_default, false, meshtastic_ModuleConfig_ExternalNotificationConfig_init_default, false, meshtastic_ModuleConfig_StoreForwardConfig_init_default, false, meshtastic_ModuleConfig_RangeTestConfig_init_default, false, meshtastic_ModuleConfig_TelemetryConfig_init_default, false, meshtastic_ModuleConfig_CannedMessageConfig_init_default, 0, false, meshtastic_ModuleConfig_AudioConfig_init_default, false, meshtastic_ModuleConfig_RemoteHardwareConfig_init_default, false, meshtastic_ModuleConfig_NeighborInfoConfig_init_default, false, meshtastic_ModuleConfig_AmbientLightingConfig_init_default, false, meshtastic_ModuleConfig_DetectionSensorConfig_init_default, false, meshtastic_ModuleConfig_PaxcounterConfig_init_default}
+#define meshtastic_LocalModuleConfig_init_default {false, meshtastic_ModuleConfig_MQTTConfig_init_default, false, meshtastic_ModuleConfig_SerialConfig_init_default, false, meshtastic_ModuleConfig_ExternalNotificationConfig_init_default, false, meshtastic_ModuleConfig_StoreForwardConfig_init_default, false, meshtastic_ModuleConfig_RangeTestConfig_init_default, false, meshtastic_ModuleConfig_TelemetryConfig_init_default, false, meshtastic_ModuleConfig_CannedMessageConfig_init_default, 0, false, meshtastic_ModuleConfig_AudioConfig_init_default, false, meshtastic_ModuleConfig_RemoteHardwareConfig_init_default, false, meshtastic_ModuleConfig_NeighborInfoConfig_init_default, false, meshtastic_ModuleConfig_AmbientLightingConfig_init_default, false, meshtastic_ModuleConfig_DetectionSensorConfig_init_default, false, meshtastic_ModuleConfig_PaxcounterConfig_init_default, false, meshtastic_ModuleConfig_AntennaInfoConfig_init_default}
 #define meshtastic_LocalConfig_init_zero         {false, meshtastic_Config_DeviceConfig_init_zero, false, meshtastic_Config_PositionConfig_init_zero, false, meshtastic_Config_PowerConfig_init_zero, false, meshtastic_Config_NetworkConfig_init_zero, false, meshtastic_Config_DisplayConfig_init_zero, false, meshtastic_Config_LoRaConfig_init_zero, false, meshtastic_Config_BluetoothConfig_init_zero, 0, false, meshtastic_Config_SecurityConfig_init_zero}
-#define meshtastic_LocalModuleConfig_init_zero   {false, meshtastic_ModuleConfig_MQTTConfig_init_zero, false, meshtastic_ModuleConfig_SerialConfig_init_zero, false, meshtastic_ModuleConfig_ExternalNotificationConfig_init_zero, false, meshtastic_ModuleConfig_StoreForwardConfig_init_zero, false, meshtastic_ModuleConfig_RangeTestConfig_init_zero, false, meshtastic_ModuleConfig_TelemetryConfig_init_zero, false, meshtastic_ModuleConfig_CannedMessageConfig_init_zero, 0, false, meshtastic_ModuleConfig_AudioConfig_init_zero, false, meshtastic_ModuleConfig_RemoteHardwareConfig_init_zero, false, meshtastic_ModuleConfig_NeighborInfoConfig_init_zero, false, meshtastic_ModuleConfig_AmbientLightingConfig_init_zero, false, meshtastic_ModuleConfig_DetectionSensorConfig_init_zero, false, meshtastic_ModuleConfig_PaxcounterConfig_init_zero}
+#define meshtastic_LocalModuleConfig_init_zero   {false, meshtastic_ModuleConfig_MQTTConfig_init_zero, false, meshtastic_ModuleConfig_SerialConfig_init_zero, false, meshtastic_ModuleConfig_ExternalNotificationConfig_init_zero, false, meshtastic_ModuleConfig_StoreForwardConfig_init_zero, false, meshtastic_ModuleConfig_RangeTestConfig_init_zero, false, meshtastic_ModuleConfig_TelemetryConfig_init_zero, false, meshtastic_ModuleConfig_CannedMessageConfig_init_zero, 0, false, meshtastic_ModuleConfig_AudioConfig_init_zero, false, meshtastic_ModuleConfig_RemoteHardwareConfig_init_zero, false, meshtastic_ModuleConfig_NeighborInfoConfig_init_zero, false, meshtastic_ModuleConfig_AmbientLightingConfig_init_zero, false, meshtastic_ModuleConfig_DetectionSensorConfig_init_zero, false, meshtastic_ModuleConfig_PaxcounterConfig_init_zero, false, meshtastic_ModuleConfig_AntennaInfoConfig_init_zero}
 
 /* Field tags (for use in manual encoding/decoding) */
 #define meshtastic_LocalConfig_device_tag        1
@@ -124,6 +127,7 @@ extern "C" {
 #define meshtastic_LocalModuleConfig_ambient_lighting_tag 12
 #define meshtastic_LocalModuleConfig_detection_sensor_tag 13
 #define meshtastic_LocalModuleConfig_paxcounter_tag 14
+#define meshtastic_LocalModuleConfig_antenna_info_tag 15
 
 /* Struct field encoding specification for nanopb */
 #define meshtastic_LocalConfig_FIELDLIST(X, a) \
@@ -161,7 +165,8 @@ X(a, STATIC,   OPTIONAL, MESSAGE,  remote_hardware,  10) \
 X(a, STATIC,   OPTIONAL, MESSAGE,  neighbor_info,    11) \
 X(a, STATIC,   OPTIONAL, MESSAGE,  ambient_lighting,  12) \
 X(a, STATIC,   OPTIONAL, MESSAGE,  detection_sensor,  13) \
-X(a, STATIC,   OPTIONAL, MESSAGE,  paxcounter,       14)
+X(a, STATIC,   OPTIONAL, MESSAGE,  paxcounter,       14) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  antenna_info,     15)
 #define meshtastic_LocalModuleConfig_CALLBACK NULL
 #define meshtastic_LocalModuleConfig_DEFAULT NULL
 #define meshtastic_LocalModuleConfig_mqtt_MSGTYPE meshtastic_ModuleConfig_MQTTConfig
@@ -177,6 +182,7 @@ X(a, STATIC,   OPTIONAL, MESSAGE,  paxcounter,       14)
 #define meshtastic_LocalModuleConfig_ambient_lighting_MSGTYPE meshtastic_ModuleConfig_AmbientLightingConfig
 #define meshtastic_LocalModuleConfig_detection_sensor_MSGTYPE meshtastic_ModuleConfig_DetectionSensorConfig
 #define meshtastic_LocalModuleConfig_paxcounter_MSGTYPE meshtastic_ModuleConfig_PaxcounterConfig
+#define meshtastic_LocalModuleConfig_antenna_info_MSGTYPE meshtastic_ModuleConfig_AntennaInfoConfig
 
 extern const pb_msgdesc_t meshtastic_LocalConfig_msg;
 extern const pb_msgdesc_t meshtastic_LocalModuleConfig_msg;
@@ -188,7 +194,7 @@ extern const pb_msgdesc_t meshtastic_LocalModuleConfig_msg;
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_LOCALONLY_PB_H_MAX_SIZE meshtastic_LocalConfig_size
 #define meshtastic_LocalConfig_size              743
-#define meshtastic_LocalModuleConfig_size        669
+#define meshtastic_LocalModuleConfig_size        703
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/mesh/generated/meshtastic/mesh.pb.cpp
+++ b/src/mesh/generated/meshtastic/mesh.pb.cpp
@@ -66,6 +66,9 @@ PB_BIND(meshtastic_Neighbor, meshtastic_Neighbor, AUTO)
 PB_BIND(meshtastic_DeviceMetadata, meshtastic_DeviceMetadata, AUTO)
 
 
+PB_BIND(meshtastic_AntennaInfo, meshtastic_AntennaInfo, AUTO)
+
+
 PB_BIND(meshtastic_Heartbeat, meshtastic_Heartbeat, AUTO)
 
 

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -417,7 +417,7 @@ typedef enum _meshtastic_Routing_Error {
  (values must be <= 127 to keep protobuf field to one byte in size.
  Detailed background on this field:
  I noticed a funny side effect of lora being so slow: Usually when making
- a protocol there isn’t much need to use message priority to change the order
+ a protocol there isn't much need to use message priority to change the order
  of transmission (because interfaces are fairly fast).
  But for lora where packets can take a few seconds each, it is very important
  to make sure that critical packets are sent ASAP.
@@ -977,7 +977,7 @@ typedef struct _meshtastic_DeviceMetadata {
     bool hasBluetooth;
     /* Indicates that the device has an ethernet peripheral */
     bool hasEthernet;
-    /* Indicates that the device's role in the mesh */
+    /* Indicates the device's role in the mesh */
     meshtastic_Config_DeviceConfig_Role role;
     /* Indicates the device's current enabled position flags */
     uint32_t position_flags;
@@ -1044,6 +1044,22 @@ typedef struct _meshtastic_FromRadio {
         meshtastic_DeviceUIConfig deviceuiConfig;
     };
 } meshtastic_FromRadio;
+
+/* Antenna information message for sharing antenna details across the mesh */
+typedef struct _meshtastic_AntennaInfo {
+    /* The node ID of the node sending antenna information */
+    uint32_t node_id;
+    /* Antenna height in meters above ground level */
+    float height_m;
+    /* Antenna azimuth in degrees (0-360, where 0 is North) */
+    uint32_t azimuth_degrees;
+    /* Antenna orientation (0=vertical, 90=horizontal, etc.) */
+    uint32_t orientation_degrees;
+    /* Effective Isotropic Radiated Power (EIRP) in dBm */
+    float eirp_dbm;
+    /* Timestamp when this information was last updated */
+    uint32_t last_updated;
+} meshtastic_AntennaInfo;
 
 /* A heartbeat message is sent to the node from the client to keep the connection alive.
  This is currently only needed to keep serial connections alive, but can be used by any PhoneAPI. */
@@ -1205,6 +1221,7 @@ extern "C" {
 
 
 
+
 /* Initializer values for message structs */
 #define meshtastic_Position_init_default         {false, 0, false, 0, false, 0, 0, _meshtastic_Position_LocSource_MIN, _meshtastic_Position_AltSource_MIN, 0, 0, false, 0, false, 0, 0, 0, 0, 0, false, 0, false, 0, 0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_User_init_default             {"", "", "", {0}, _meshtastic_HardwareModel_MIN, 0, _meshtastic_Config_DeviceConfig_Role_MIN, {0, {0}}, false, 0}
@@ -1226,6 +1243,7 @@ extern "C" {
 #define meshtastic_NeighborInfo_init_default     {0, 0, 0, 0, {meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default, meshtastic_Neighbor_init_default}}
 #define meshtastic_Neighbor_init_default         {0, 0, 0, 0}
 #define meshtastic_DeviceMetadata_init_default   {"", 0, 0, 0, 0, 0, _meshtastic_Config_DeviceConfig_Role_MIN, 0, _meshtastic_HardwareModel_MIN, 0, 0, 0}
+#define meshtastic_AntennaInfo_init_default      {0, 0, 0, 0, 0, 0}
 #define meshtastic_Heartbeat_init_default        {0}
 #define meshtastic_NodeRemoteHardwarePin_init_default {0, false, meshtastic_RemoteHardwarePin_init_default}
 #define meshtastic_ChunkedPayload_init_default   {0, 0, 0, {0, {0}}}
@@ -1251,6 +1269,7 @@ extern "C" {
 #define meshtastic_NeighborInfo_init_zero        {0, 0, 0, 0, {meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero, meshtastic_Neighbor_init_zero}}
 #define meshtastic_Neighbor_init_zero            {0, 0, 0, 0}
 #define meshtastic_DeviceMetadata_init_zero      {"", 0, 0, 0, 0, 0, _meshtastic_Config_DeviceConfig_Role_MIN, 0, _meshtastic_HardwareModel_MIN, 0, 0, 0}
+#define meshtastic_AntennaInfo_init_zero         {0, 0, 0, 0, 0, 0}
 #define meshtastic_Heartbeat_init_zero           {0}
 #define meshtastic_NodeRemoteHardwarePin_init_zero {0, false, meshtastic_RemoteHardwarePin_init_zero}
 #define meshtastic_ChunkedPayload_init_zero      {0, 0, 0, {0, {0}}}
@@ -1407,6 +1426,12 @@ extern "C" {
 #define meshtastic_FromRadio_fileInfo_tag        15
 #define meshtastic_FromRadio_clientNotification_tag 16
 #define meshtastic_FromRadio_deviceuiConfig_tag  17
+#define meshtastic_AntennaInfo_node_id_tag       1
+#define meshtastic_AntennaInfo_height_m_tag      2
+#define meshtastic_AntennaInfo_azimuth_degrees_tag 3
+#define meshtastic_AntennaInfo_orientation_degrees_tag 4
+#define meshtastic_AntennaInfo_eirp_dbm_tag      5
+#define meshtastic_AntennaInfo_last_updated_tag  6
 #define meshtastic_ToRadio_packet_tag            1
 #define meshtastic_ToRadio_want_config_id_tag    3
 #define meshtastic_ToRadio_disconnect_tag        4
@@ -1686,6 +1711,16 @@ X(a, STATIC,   SINGULAR, UINT32,   excluded_modules,  12)
 #define meshtastic_DeviceMetadata_CALLBACK NULL
 #define meshtastic_DeviceMetadata_DEFAULT NULL
 
+#define meshtastic_AntennaInfo_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UINT32,   node_id,           1) \
+X(a, STATIC,   SINGULAR, FLOAT,    height_m,          2) \
+X(a, STATIC,   SINGULAR, UINT32,   azimuth_degrees,   3) \
+X(a, STATIC,   SINGULAR, UINT32,   orientation_degrees,   4) \
+X(a, STATIC,   SINGULAR, FLOAT,    eirp_dbm,          5) \
+X(a, STATIC,   SINGULAR, FIXED32,  last_updated,      6)
+#define meshtastic_AntennaInfo_CALLBACK NULL
+#define meshtastic_AntennaInfo_DEFAULT NULL
+
 #define meshtastic_Heartbeat_FIELDLIST(X, a) \
 
 #define meshtastic_Heartbeat_CALLBACK NULL
@@ -1740,6 +1775,7 @@ extern const pb_msgdesc_t meshtastic_Compressed_msg;
 extern const pb_msgdesc_t meshtastic_NeighborInfo_msg;
 extern const pb_msgdesc_t meshtastic_Neighbor_msg;
 extern const pb_msgdesc_t meshtastic_DeviceMetadata_msg;
+extern const pb_msgdesc_t meshtastic_AntennaInfo_msg;
 extern const pb_msgdesc_t meshtastic_Heartbeat_msg;
 extern const pb_msgdesc_t meshtastic_NodeRemoteHardwarePin_msg;
 extern const pb_msgdesc_t meshtastic_ChunkedPayload_msg;
@@ -1767,6 +1803,7 @@ extern const pb_msgdesc_t meshtastic_ChunkedPayloadResponse_msg;
 #define meshtastic_NeighborInfo_fields &meshtastic_NeighborInfo_msg
 #define meshtastic_Neighbor_fields &meshtastic_Neighbor_msg
 #define meshtastic_DeviceMetadata_fields &meshtastic_DeviceMetadata_msg
+#define meshtastic_AntennaInfo_fields &meshtastic_AntennaInfo_msg
 #define meshtastic_Heartbeat_fields &meshtastic_Heartbeat_msg
 #define meshtastic_NodeRemoteHardwarePin_fields &meshtastic_NodeRemoteHardwarePin_msg
 #define meshtastic_ChunkedPayload_fields &meshtastic_ChunkedPayload_msg
@@ -1777,6 +1814,7 @@ extern const pb_msgdesc_t meshtastic_ChunkedPayloadResponse_msg;
 /* meshtastic_resend_chunks_size depends on runtime parameters */
 /* meshtastic_ChunkedPayloadResponse_size depends on runtime parameters */
 #define MESHTASTIC_MESHTASTIC_MESH_PB_H_MAX_SIZE meshtastic_FromRadio_size
+#define meshtastic_AntennaInfo_size              33
 #define meshtastic_ChunkedPayload_size           245
 #define meshtastic_ClientNotification_size       415
 #define meshtastic_Compressed_size               239

--- a/src/mesh/generated/meshtastic/module_config.pb.cpp
+++ b/src/mesh/generated/meshtastic/module_config.pb.cpp
@@ -21,6 +21,9 @@ PB_BIND(meshtastic_ModuleConfig_RemoteHardwareConfig, meshtastic_ModuleConfig_Re
 PB_BIND(meshtastic_ModuleConfig_NeighborInfoConfig, meshtastic_ModuleConfig_NeighborInfoConfig, AUTO)
 
 
+PB_BIND(meshtastic_ModuleConfig_AntennaInfoConfig, meshtastic_ModuleConfig_AntennaInfoConfig, AUTO)
+
+
 PB_BIND(meshtastic_ModuleConfig_DetectionSensorConfig, meshtastic_ModuleConfig_DetectionSensorConfig, AUTO)
 
 

--- a/src/mesh/generated/meshtastic/module_config.pb.h
+++ b/src/mesh/generated/meshtastic/module_config.pb.h
@@ -180,8 +180,7 @@ typedef struct _meshtastic_ModuleConfig_AntennaInfoConfig {
     uint32_t orientation_degrees;
     /* Effective Isotropic Radiated Power (EIRP) in dBm */
     float eirp_dbm;
-    /* Whether in addition to sending it to MQTT and the PhoneAPI, our AntennaInfo should be transmitted over LoRa.
- Note that this is not available on a channel with default key and name. */
+    /* Whether in addition to sending it to MQTT and the PhoneAPI, our AntennaInfo should be transmitted over LoRa. */
     bool transmit_over_lora;
 } meshtastic_ModuleConfig_AntennaInfoConfig;
 

--- a/src/mesh/generated/meshtastic/module_config.pb.h
+++ b/src/mesh/generated/meshtastic/module_config.pb.h
@@ -82,11 +82,7 @@ typedef enum _meshtastic_ModuleConfig_SerialConfig_Serial_Mode {
     meshtastic_ModuleConfig_SerialConfig_Serial_Mode_WS85 = 6,
     /* VE.Direct is a serial protocol used by Victron Energy products
  https://beta.ivc.no/wiki/index.php/Victron_VE_Direct_DIY_Cable */
-    meshtastic_ModuleConfig_SerialConfig_Serial_Mode_VE_DIRECT = 7,
-    /* MQTT protocol for sending/receiving MQTT messages over UART */
-    meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MQTT = 8,
-    /* PACKET mode for sending/receiving raw packets over UART */
-    meshtastic_ModuleConfig_SerialConfig_Serial_Mode_PACKET = 9
+    meshtastic_ModuleConfig_SerialConfig_Serial_Mode_VE_DIRECT = 7
 } meshtastic_ModuleConfig_SerialConfig_Serial_Mode;
 
 /* TODO: REPLACE */
@@ -498,8 +494,8 @@ extern "C" {
 #define _meshtastic_ModuleConfig_SerialConfig_Serial_Baud_ARRAYSIZE ((meshtastic_ModuleConfig_SerialConfig_Serial_Baud)(meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_921600+1))
 
 #define _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MIN meshtastic_ModuleConfig_SerialConfig_Serial_Mode_DEFAULT
-#define _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MAX meshtastic_ModuleConfig_SerialConfig_Serial_Mode_PACKET
-#define _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_ARRAYSIZE ((meshtastic_ModuleConfig_SerialConfig_Serial_Mode)(meshtastic_ModuleConfig_SerialConfig_Serial_Mode_PACKET+1))
+#define _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MAX meshtastic_ModuleConfig_SerialConfig_Serial_Mode_VE_DIRECT
+#define _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_ARRAYSIZE ((meshtastic_ModuleConfig_SerialConfig_Serial_Mode)(meshtastic_ModuleConfig_SerialConfig_Serial_Mode_VE_DIRECT+1))
 
 #define _meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_MIN meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_NONE
 #define _meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_MAX meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_BACK

--- a/src/mesh/generated/meshtastic/module_config.pb.h
+++ b/src/mesh/generated/meshtastic/module_config.pb.h
@@ -82,7 +82,11 @@ typedef enum _meshtastic_ModuleConfig_SerialConfig_Serial_Mode {
     meshtastic_ModuleConfig_SerialConfig_Serial_Mode_WS85 = 6,
     /* VE.Direct is a serial protocol used by Victron Energy products
  https://beta.ivc.no/wiki/index.php/Victron_VE_Direct_DIY_Cable */
-    meshtastic_ModuleConfig_SerialConfig_Serial_Mode_VE_DIRECT = 7
+    meshtastic_ModuleConfig_SerialConfig_Serial_Mode_VE_DIRECT = 7,
+    /* MQTT protocol for sending/receiving MQTT messages over UART */
+    meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MQTT = 8,
+    /* PACKET mode for sending/receiving raw packets over UART */
+    meshtastic_ModuleConfig_SerialConfig_Serial_Mode_PACKET = 9
 } meshtastic_ModuleConfig_SerialConfig_Serial_Mode;
 
 /* TODO: REPLACE */
@@ -164,6 +168,26 @@ typedef struct _meshtastic_ModuleConfig_NeighborInfoConfig {
  Note that this is not available on a channel with default key and name. */
     bool transmit_over_lora;
 } meshtastic_ModuleConfig_NeighborInfoConfig;
+
+/* AntennaInfoModule Config */
+typedef struct _meshtastic_ModuleConfig_AntennaInfoConfig {
+    /* Whether the Module is enabled */
+    bool enabled;
+    /* Interval in seconds of how often we should try to send our
+ Antenna Info (minimum is 3600, i.e., 1 hour) */
+    uint32_t update_interval;
+    /* Antenna height in meters above ground level */
+    float height_m;
+    /* Antenna azimuth in degrees (0-360, where 0 is North) */
+    uint32_t azimuth_degrees;
+    /* Antenna orientation in degrees (0=vertical, 90=horizontal, etc.) */
+    uint32_t orientation_degrees;
+    /* Effective Isotropic Radiated Power (EIRP) in dBm */
+    float eirp_dbm;
+    /* Whether in addition to sending it to MQTT and the PhoneAPI, our AntennaInfo should be transmitted over LoRa.
+ Note that this is not available on a channel with default key and name. */
+    bool transmit_over_lora;
+} meshtastic_ModuleConfig_AntennaInfoConfig;
 
 /* Detection Sensor Module Config */
 typedef struct _meshtastic_ModuleConfig_DetectionSensorConfig {
@@ -446,6 +470,8 @@ typedef struct _meshtastic_ModuleConfig {
         meshtastic_ModuleConfig_DetectionSensorConfig detection_sensor;
         /* TODO: REPLACE */
         meshtastic_ModuleConfig_PaxcounterConfig paxcounter;
+        /* TODO: REPLACE */
+        meshtastic_ModuleConfig_AntennaInfoConfig antenna_info;
     } payload_variant;
 } meshtastic_ModuleConfig;
 
@@ -472,12 +498,13 @@ extern "C" {
 #define _meshtastic_ModuleConfig_SerialConfig_Serial_Baud_ARRAYSIZE ((meshtastic_ModuleConfig_SerialConfig_Serial_Baud)(meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_921600+1))
 
 #define _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MIN meshtastic_ModuleConfig_SerialConfig_Serial_Mode_DEFAULT
-#define _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MAX meshtastic_ModuleConfig_SerialConfig_Serial_Mode_VE_DIRECT
-#define _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_ARRAYSIZE ((meshtastic_ModuleConfig_SerialConfig_Serial_Mode)(meshtastic_ModuleConfig_SerialConfig_Serial_Mode_VE_DIRECT+1))
+#define _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_MAX meshtastic_ModuleConfig_SerialConfig_Serial_Mode_PACKET
+#define _meshtastic_ModuleConfig_SerialConfig_Serial_Mode_ARRAYSIZE ((meshtastic_ModuleConfig_SerialConfig_Serial_Mode)(meshtastic_ModuleConfig_SerialConfig_Serial_Mode_PACKET+1))
 
 #define _meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_MIN meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_NONE
 #define _meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_MAX meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_BACK
 #define _meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_ARRAYSIZE ((meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar)(meshtastic_ModuleConfig_CannedMessageConfig_InputEventChar_BACK+1))
+
 
 
 
@@ -510,6 +537,7 @@ extern "C" {
 #define meshtastic_ModuleConfig_MapReportSettings_init_default {0, 0, 0}
 #define meshtastic_ModuleConfig_RemoteHardwareConfig_init_default {0, 0, 0, {meshtastic_RemoteHardwarePin_init_default, meshtastic_RemoteHardwarePin_init_default, meshtastic_RemoteHardwarePin_init_default, meshtastic_RemoteHardwarePin_init_default}}
 #define meshtastic_ModuleConfig_NeighborInfoConfig_init_default {0, 0, 0}
+#define meshtastic_ModuleConfig_AntennaInfoConfig_init_default {0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_DetectionSensorConfig_init_default {0, 0, 0, 0, "", 0, _meshtastic_ModuleConfig_DetectionSensorConfig_TriggerType_MIN, 0}
 #define meshtastic_ModuleConfig_AudioConfig_init_default {0, 0, _meshtastic_ModuleConfig_AudioConfig_Audio_Baud_MIN, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_PaxcounterConfig_init_default {0, 0, 0, 0}
@@ -526,6 +554,7 @@ extern "C" {
 #define meshtastic_ModuleConfig_MapReportSettings_init_zero {0, 0, 0}
 #define meshtastic_ModuleConfig_RemoteHardwareConfig_init_zero {0, 0, 0, {meshtastic_RemoteHardwarePin_init_zero, meshtastic_RemoteHardwarePin_init_zero, meshtastic_RemoteHardwarePin_init_zero, meshtastic_RemoteHardwarePin_init_zero}}
 #define meshtastic_ModuleConfig_NeighborInfoConfig_init_zero {0, 0, 0}
+#define meshtastic_ModuleConfig_AntennaInfoConfig_init_zero {0, 0, 0, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_DetectionSensorConfig_init_zero {0, 0, 0, 0, "", 0, _meshtastic_ModuleConfig_DetectionSensorConfig_TriggerType_MIN, 0}
 #define meshtastic_ModuleConfig_AudioConfig_init_zero {0, 0, _meshtastic_ModuleConfig_AudioConfig_Audio_Baud_MIN, 0, 0, 0, 0}
 #define meshtastic_ModuleConfig_PaxcounterConfig_init_zero {0, 0, 0, 0}
@@ -556,6 +585,13 @@ extern "C" {
 #define meshtastic_ModuleConfig_NeighborInfoConfig_enabled_tag 1
 #define meshtastic_ModuleConfig_NeighborInfoConfig_update_interval_tag 2
 #define meshtastic_ModuleConfig_NeighborInfoConfig_transmit_over_lora_tag 3
+#define meshtastic_ModuleConfig_AntennaInfoConfig_enabled_tag 1
+#define meshtastic_ModuleConfig_AntennaInfoConfig_update_interval_tag 2
+#define meshtastic_ModuleConfig_AntennaInfoConfig_height_m_tag 3
+#define meshtastic_ModuleConfig_AntennaInfoConfig_azimuth_degrees_tag 4
+#define meshtastic_ModuleConfig_AntennaInfoConfig_orientation_degrees_tag 5
+#define meshtastic_ModuleConfig_AntennaInfoConfig_eirp_dbm_tag 6
+#define meshtastic_ModuleConfig_AntennaInfoConfig_transmit_over_lora_tag 7
 #define meshtastic_ModuleConfig_DetectionSensorConfig_enabled_tag 1
 #define meshtastic_ModuleConfig_DetectionSensorConfig_minimum_broadcast_secs_tag 2
 #define meshtastic_ModuleConfig_DetectionSensorConfig_state_broadcast_secs_tag 3
@@ -655,6 +691,7 @@ extern "C" {
 #define meshtastic_ModuleConfig_ambient_lighting_tag 11
 #define meshtastic_ModuleConfig_detection_sensor_tag 12
 #define meshtastic_ModuleConfig_paxcounter_tag   13
+#define meshtastic_ModuleConfig_antenna_info_tag 14
 
 /* Struct field encoding specification for nanopb */
 #define meshtastic_ModuleConfig_FIELDLIST(X, a) \
@@ -670,7 +707,8 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,remote_hardware,payload_vari
 X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,neighbor_info,payload_variant.neighbor_info),  10) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,ambient_lighting,payload_variant.ambient_lighting),  11) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,detection_sensor,payload_variant.detection_sensor),  12) \
-X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,paxcounter,payload_variant.paxcounter),  13)
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,paxcounter,payload_variant.paxcounter),  13) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,antenna_info,payload_variant.antenna_info),  14)
 #define meshtastic_ModuleConfig_CALLBACK NULL
 #define meshtastic_ModuleConfig_DEFAULT NULL
 #define meshtastic_ModuleConfig_payload_variant_mqtt_MSGTYPE meshtastic_ModuleConfig_MQTTConfig
@@ -686,6 +724,7 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,paxcounter,payload_variant.p
 #define meshtastic_ModuleConfig_payload_variant_ambient_lighting_MSGTYPE meshtastic_ModuleConfig_AmbientLightingConfig
 #define meshtastic_ModuleConfig_payload_variant_detection_sensor_MSGTYPE meshtastic_ModuleConfig_DetectionSensorConfig
 #define meshtastic_ModuleConfig_payload_variant_paxcounter_MSGTYPE meshtastic_ModuleConfig_PaxcounterConfig
+#define meshtastic_ModuleConfig_payload_variant_antenna_info_MSGTYPE meshtastic_ModuleConfig_AntennaInfoConfig
 
 #define meshtastic_ModuleConfig_MQTTConfig_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, BOOL,     enabled,           1) \
@@ -724,6 +763,17 @@ X(a, STATIC,   SINGULAR, UINT32,   update_interval,   2) \
 X(a, STATIC,   SINGULAR, BOOL,     transmit_over_lora,   3)
 #define meshtastic_ModuleConfig_NeighborInfoConfig_CALLBACK NULL
 #define meshtastic_ModuleConfig_NeighborInfoConfig_DEFAULT NULL
+
+#define meshtastic_ModuleConfig_AntennaInfoConfig_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, BOOL,     enabled,           1) \
+X(a, STATIC,   SINGULAR, UINT32,   update_interval,   2) \
+X(a, STATIC,   SINGULAR, FLOAT,    height_m,          3) \
+X(a, STATIC,   SINGULAR, UINT32,   azimuth_degrees,   4) \
+X(a, STATIC,   SINGULAR, UINT32,   orientation_degrees,   5) \
+X(a, STATIC,   SINGULAR, FLOAT,    eirp_dbm,          6) \
+X(a, STATIC,   SINGULAR, BOOL,     transmit_over_lora,   7)
+#define meshtastic_ModuleConfig_AntennaInfoConfig_CALLBACK NULL
+#define meshtastic_ModuleConfig_AntennaInfoConfig_DEFAULT NULL
 
 #define meshtastic_ModuleConfig_DetectionSensorConfig_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, BOOL,     enabled,           1) \
@@ -857,6 +907,7 @@ extern const pb_msgdesc_t meshtastic_ModuleConfig_MQTTConfig_msg;
 extern const pb_msgdesc_t meshtastic_ModuleConfig_MapReportSettings_msg;
 extern const pb_msgdesc_t meshtastic_ModuleConfig_RemoteHardwareConfig_msg;
 extern const pb_msgdesc_t meshtastic_ModuleConfig_NeighborInfoConfig_msg;
+extern const pb_msgdesc_t meshtastic_ModuleConfig_AntennaInfoConfig_msg;
 extern const pb_msgdesc_t meshtastic_ModuleConfig_DetectionSensorConfig_msg;
 extern const pb_msgdesc_t meshtastic_ModuleConfig_AudioConfig_msg;
 extern const pb_msgdesc_t meshtastic_ModuleConfig_PaxcounterConfig_msg;
@@ -875,6 +926,7 @@ extern const pb_msgdesc_t meshtastic_RemoteHardwarePin_msg;
 #define meshtastic_ModuleConfig_MapReportSettings_fields &meshtastic_ModuleConfig_MapReportSettings_msg
 #define meshtastic_ModuleConfig_RemoteHardwareConfig_fields &meshtastic_ModuleConfig_RemoteHardwareConfig_msg
 #define meshtastic_ModuleConfig_NeighborInfoConfig_fields &meshtastic_ModuleConfig_NeighborInfoConfig_msg
+#define meshtastic_ModuleConfig_AntennaInfoConfig_fields &meshtastic_ModuleConfig_AntennaInfoConfig_msg
 #define meshtastic_ModuleConfig_DetectionSensorConfig_fields &meshtastic_ModuleConfig_DetectionSensorConfig_msg
 #define meshtastic_ModuleConfig_AudioConfig_fields &meshtastic_ModuleConfig_AudioConfig_msg
 #define meshtastic_ModuleConfig_PaxcounterConfig_fields &meshtastic_ModuleConfig_PaxcounterConfig_msg
@@ -890,6 +942,7 @@ extern const pb_msgdesc_t meshtastic_RemoteHardwarePin_msg;
 /* Maximum encoded size of messages (where known) */
 #define MESHTASTIC_MESHTASTIC_MODULE_CONFIG_PB_H_MAX_SIZE meshtastic_ModuleConfig_size
 #define meshtastic_ModuleConfig_AmbientLightingConfig_size 14
+#define meshtastic_ModuleConfig_AntennaInfoConfig_size 32
 #define meshtastic_ModuleConfig_AudioConfig_size 19
 #define meshtastic_ModuleConfig_CannedMessageConfig_size 49
 #define meshtastic_ModuleConfig_DetectionSensorConfig_size 44

--- a/src/mesh/generated/meshtastic/portnums.pb.h
+++ b/src/mesh/generated/meshtastic/portnums.pb.h
@@ -121,6 +121,9 @@ typedef enum _meshtastic_PortNum {
     /* Aggregates edge info for the network by sending out a list of each node's neighbors
  ENCODING: Protobuf */
     meshtastic_PortNum_NEIGHBORINFO_APP = 71,
+    /* Antenna information app for sharing antenna details across the mesh
+ ENCODING: Protobuf */
+    meshtastic_PortNum_ANTENNA_INFO_APP = 35,
     /* ATAK Plugin
  Portnum for payloads from the official Meshtastic ATAK plugin */
     meshtastic_PortNum_ATAK_PLUGIN = 72,

--- a/src/mesh/generated/meshtastic/portnums.pb.h
+++ b/src/mesh/generated/meshtastic/portnums.pb.h
@@ -84,6 +84,9 @@ typedef enum _meshtastic_PortNum {
     /* Paxcounter lib included in the firmware
  ENCODING: protobuf */
     meshtastic_PortNum_PAXCOUNTER_APP = 34,
+    /* Antenna information app for sharing antenna details across the mesh
+ ENCODING: Protobuf */
+    meshtastic_PortNum_ANTENNA_INFO_APP = 35,
     /* Provides a hardware serial interface to send and receive from the Meshtastic network.
  Connect to the RX/TX pins of a device with 38400 8N1. Packets received from the Meshtastic
  network is forwarded to the RX pin while sending a packet to TX will go out to the Mesh network.
@@ -121,9 +124,6 @@ typedef enum _meshtastic_PortNum {
     /* Aggregates edge info for the network by sending out a list of each node's neighbors
  ENCODING: Protobuf */
     meshtastic_PortNum_NEIGHBORINFO_APP = 71,
-    /* Antenna information app for sharing antenna details across the mesh
- ENCODING: Protobuf */
-    meshtastic_PortNum_ANTENNA_INFO_APP = 35,
     /* ATAK Plugin
  Portnum for payloads from the official Meshtastic ATAK plugin */
     meshtastic_PortNum_ATAK_PLUGIN = 72,

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -788,10 +788,10 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
     case meshtastic_ModuleConfig_antenna_info_tag:
         LOG_INFO("Set module config: Antenna Info");
         moduleConfig.has_antenna_info = true;
-        // if (moduleConfig.antenna_info.update_interval < min_antenna_info_broadcast_secs) {
-        //     LOG_DEBUG("Tried to set update_interval too low, setting to %d", default_antenna_info_broadcast_secs);
-        //     moduleConfig.antenna_info.update_interval = default_antenna_info_broadcast_secs;
-        // }
+        if (moduleConfig.antenna_info.update_interval < min_antenna_info_broadcast_secs) {
+            LOG_DEBUG("Tried to set update_interval too low, setting to %d", default_antenna_info_broadcast_secs);
+            moduleConfig.antenna_info.update_interval = default_antenna_info_broadcast_secs;
+        }
         moduleConfig.antenna_info = c.payload_variant.antenna_info;
         break;
     case meshtastic_ModuleConfig_detection_sensor_tag:

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -785,6 +785,15 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
         }
         moduleConfig.neighbor_info = c.payload_variant.neighbor_info;
         break;
+    case meshtastic_ModuleConfig_antenna_info_tag:
+        LOG_INFO("Set module config: Antenna Info");
+        moduleConfig.has_antenna_info = true;
+        if (moduleConfig.antenna_info.update_interval < min_antenna_info_broadcast_secs) {
+            LOG_DEBUG("Tried to set update_interval too low, setting to %d", default_antenna_info_broadcast_secs);
+            moduleConfig.antenna_info.update_interval = default_antenna_info_broadcast_secs;
+        }
+        moduleConfig.antenna_info = c.payload_variant.antenna_info;
+        break;
     case meshtastic_ModuleConfig_detection_sensor_tag:
         LOG_INFO("Set module config: Detection Sensor");
         moduleConfig.has_detection_sensor = true;

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -788,10 +788,10 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
     case meshtastic_ModuleConfig_antenna_info_tag:
         LOG_INFO("Set module config: Antenna Info");
         moduleConfig.has_antenna_info = true;
-        if (moduleConfig.antenna_info.update_interval < min_antenna_info_broadcast_secs) {
-            LOG_DEBUG("Tried to set update_interval too low, setting to %d", default_antenna_info_broadcast_secs);
-            moduleConfig.antenna_info.update_interval = default_antenna_info_broadcast_secs;
-        }
+        // if (moduleConfig.antenna_info.update_interval < min_antenna_info_broadcast_secs) {
+        //     LOG_DEBUG("Tried to set update_interval too low, setting to %d", default_antenna_info_broadcast_secs);
+        //     moduleConfig.antenna_info.update_interval = default_antenna_info_broadcast_secs;
+        // }
         moduleConfig.antenna_info = c.payload_variant.antenna_info;
         break;
     case meshtastic_ModuleConfig_detection_sensor_tag:

--- a/src/modules/AntennaInfoModule.cpp
+++ b/src/modules/AntennaInfoModule.cpp
@@ -1,0 +1,118 @@
+#include "AntennaInfoModule.h"
+#include "Default.h"
+#include "MeshService.h"
+#include "NodeDB.h"
+#include "RTC.h"
+#include "Status.h"
+#include <Throttle.h>
+
+AntennaInfoModule *antennaInfoModule;
+
+/*
+Prints a single antenna info packet
+Uses LOG_DEBUG, which equates to Console.log
+NOTE: For debugging only
+*/
+void AntennaInfoModule::printAntennaInfo(const char *header, const meshtastic_AntennaInfo *ai)
+{
+    LOG_DEBUG("%s ANTENNAINFO PACKET from Node 0x%x", header, ai->node_id);
+    LOG_DEBUG("Height: %.2f m, Azimuth: %d°, Orientation: %d°, EIRP: %.1f dBm", 
+              ai->height_m, ai->azimuth_degrees, ai->orientation_degrees, ai->eirp_dbm);
+}
+
+/* Constructor */
+AntennaInfoModule::AntennaInfoModule()
+    : ProtobufModule("antennainfo", meshtastic_PortNum_ANTENNA_INFO_APP, &meshtastic_AntennaInfo_msg),
+      concurrency::OSThread("AntennaInfo")
+{
+    ourPortNum = meshtastic_PortNum_ANTENNA_INFO_APP;
+    nodeStatusObserver.observe(&nodeStatus->onNewStatus);
+
+    if (moduleConfig.antenna_info.enabled) {
+        setIntervalFromNow(Default::getConfiguredOrDefaultMs(moduleConfig.antenna_info.update_interval,
+                                                             default_antenna_info_broadcast_secs));
+    } else {
+        LOG_DEBUG("AntennaInfoModule is disabled");
+        disable();
+    }
+}
+
+/*
+Collect antenna info from the module config
+Assumes that the antennaInfo packet has been allocated
+@returns true if valid antenna info was collected
+*/
+bool AntennaInfoModule::collectAntennaInfo(meshtastic_AntennaInfo *antennaInfo)
+{
+    NodeNum my_node_id = nodeDB->getNodeNum();
+    antennaInfo->node_id = my_node_id;
+    antennaInfo->height_m = moduleConfig.antenna_info.height_m;
+    antennaInfo->azimuth_degrees = moduleConfig.antenna_info.azimuth_degrees;
+    antennaInfo->orientation_degrees = moduleConfig.antenna_info.orientation_degrees;
+    antennaInfo->eirp_dbm = moduleConfig.antenna_info.eirp_dbm;
+    antennaInfo->last_updated = getTime();
+
+    printAntennaInfo("COLLECTING", antennaInfo);
+    return true;
+}
+
+/* Send antenna info to the mesh */
+void AntennaInfoModule::sendAntennaInfo(NodeNum dest, bool wantReplies)
+{
+    meshtastic_AntennaInfo antennaInfo = meshtastic_AntennaInfo_init_zero;
+    if (collectAntennaInfo(&antennaInfo)) {
+        meshtastic_MeshPacket *p = allocDataProtobuf(antennaInfo);
+        p->to = dest;
+        p->decoded.want_response = wantReplies;
+        p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
+        printAntennaInfo("SENDING", &antennaInfo);
+        service->sendToMesh(p, RX_SRC_LOCAL, true);
+    }
+}
+
+/*
+Encompasses the full construction and sending packet to mesh
+Will be used for broadcast.
+*/
+int32_t AntennaInfoModule::runOnce()
+{
+    if (moduleConfig.antenna_info.transmit_over_lora &&
+        (!channels.isDefaultChannel(channels.getPrimaryIndex()) || !RadioInterface::uses_default_frequency_slot) &&
+        airTime->isTxAllowedChannelUtil(true) && airTime->isTxAllowedAirUtil()) {
+        sendAntennaInfo(NODENUM_BROADCAST, false);
+    } else {
+        sendAntennaInfo(NODENUM_BROADCAST_NO_LORA, false);
+    }
+    return Default::getConfiguredOrDefaultMs(moduleConfig.antenna_info.update_interval, default_antenna_info_broadcast_secs);
+}
+
+/*
+Collect a received antenna info packet from another node
+Pass it to an upper client; do not persist this data on the mesh
+*/
+bool AntennaInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_AntennaInfo *ai)
+{
+    if (ai) {
+        printAntennaInfo("RECEIVED", ai);
+        // Allow others to handle this packet
+        return false;
+    }
+    return false;
+}
+
+/*
+ * Handle status updates from the node status module
+ */
+int AntennaInfoModule::handleStatusUpdate(const meshtastic::Status *status)
+{
+    // Only respond to node status updates
+    if (status->getStatusType() == STATUS_TYPE_NODE) {
+        if (moduleConfig.antenna_info.enabled) {
+            setIntervalFromNow(Default::getConfiguredOrDefaultMs(moduleConfig.antenna_info.update_interval,
+                                                                 default_antenna_info_broadcast_secs));
+        } else {
+            disable();
+        }
+    }
+    return 0;
+} 

--- a/src/modules/AntennaInfoModule.cpp
+++ b/src/modules/AntennaInfoModule.cpp
@@ -77,7 +77,6 @@ Will be used for broadcast.
 int32_t AntennaInfoModule::runOnce()
 {
     if (moduleConfig.antenna_info.transmit_over_lora &&
-        (!channels.isDefaultChannel(channels.getPrimaryIndex()) || !RadioInterface::uses_default_frequency_slot) &&
         airTime->isTxAllowedChannelUtil(true) && airTime->isTxAllowedAirUtil()) {
         sendAntennaInfo(NODENUM_BROADCAST, false);
     } else {

--- a/src/modules/AntennaInfoModule.cpp
+++ b/src/modules/AntennaInfoModule.cpp
@@ -66,7 +66,11 @@ void AntennaInfoModule::sendAntennaInfo(NodeNum dest, bool wantReplies)
         p->decoded.want_response = wantReplies;
         p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
         printAntennaInfo("SENDING", &antennaInfo);
+        LOG_INFO("AntennaInfo: Sending packet to mesh, dest=0x%x, wantReplies=%d", dest, wantReplies);
         service->sendToMesh(p, RX_SRC_LOCAL, true);
+        LOG_INFO("AntennaInfo: Packet sent to mesh successfully");
+    } else {
+        LOG_WARN("AntennaInfo: Failed to collect antenna info, not sending packet");
     }
 }
 
@@ -76,10 +80,15 @@ Will be used for broadcast.
 */
 int32_t AntennaInfoModule::runOnce()
 {
+    LOG_INFO("AntennaInfo: runOnce() called, enabled=%d, transmit_over_lora=%d", 
+             moduleConfig.antenna_info.enabled, moduleConfig.antenna_info.transmit_over_lora);
+    
     if (moduleConfig.antenna_info.transmit_over_lora &&
         airTime->isTxAllowedChannelUtil(true) && airTime->isTxAllowedAirUtil()) {
+        LOG_INFO("AntennaInfo: Sending over LoRa (broadcast)");
         sendAntennaInfo(NODENUM_BROADCAST, false);
     } else {
+        LOG_INFO("AntennaInfo: Sending over non-LoRa (broadcast_no_lora)");
         sendAntennaInfo(NODENUM_BROADCAST_NO_LORA, false);
     }
     return Default::getConfiguredOrDefaultMs(moduleConfig.antenna_info.update_interval, default_antenna_info_broadcast_secs);

--- a/src/modules/AntennaInfoModule.h
+++ b/src/modules/AntennaInfoModule.h
@@ -1,0 +1,50 @@
+#pragma once
+#include "ProtobufModule.h"
+#include "Status.h"
+
+/*
+ * AntennaInfo module for sending antenna information to the mesh
+ */
+class AntennaInfoModule : public ProtobufModule<meshtastic_AntennaInfo>, private concurrency::OSThread
+{
+    CallbackObserver<AntennaInfoModule, const meshtastic::Status *> nodeStatusObserver =
+        CallbackObserver<AntennaInfoModule, const meshtastic::Status *>(this, &AntennaInfoModule::handleStatusUpdate);
+
+  public:
+    /*
+     * Expose the constructor
+     */
+    AntennaInfoModule();
+
+  protected:
+    /*
+     * Called to handle a particular incoming message
+     * @return true if you've guaranteed you've handled this message and no other handlers should be considered for it
+     */
+    virtual bool handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_AntennaInfo *ai) override;
+
+    /*
+     * Collect antenna info from the module config
+     * Assumes that the antennaInfo packet has been allocated
+     * @returns true if valid antenna info was collected
+     */
+    bool collectAntennaInfo(meshtastic_AntennaInfo *antennaInfo);
+
+    /*
+     * Send antenna info to the mesh
+     */
+    void sendAntennaInfo(NodeNum dest = NODENUM_BROADCAST, bool wantReplies = false);
+
+    /*
+     * Handle status updates from the node status module
+     */
+    int handleStatusUpdate(const meshtastic::Status *status);
+
+    /* Does our periodic broadcast */
+    int32_t runOnce() override;
+
+    /* These are for debugging only */
+    void printAntennaInfo(const char *header, const meshtastic_AntennaInfo *ai);
+};
+
+extern AntennaInfoModule *antennaInfoModule; 

--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -27,6 +27,9 @@
 #if !MESHTASTIC_EXCLUDE_NEIGHBORINFO
 #include "modules/NeighborInfoModule.h"
 #endif
+#if !MESHTASTIC_EXCLUDE_ANTENNAINFO
+#include "modules/AntennaInfoModule.h"
+#endif
 #if !MESHTASTIC_EXCLUDE_NODEINFO
 #include "modules/NodeInfoModule.h"
 #endif
@@ -126,6 +129,9 @@ void setupModules()
 #endif
 #if !MESHTASTIC_EXCLUDE_NEIGHBORINFO
         neighborInfoModule = new NeighborInfoModule();
+#endif
+#if !MESHTASTIC_EXCLUDE_ANTENNAINFO
+        antennaInfoModule = new AntennaInfoModule();
 #endif
 #if !MESHTASTIC_EXCLUDE_DETECTIONSENSOR
         detectionSensorModule = new DetectionSensorModule();

--- a/src/modules/Modules.h
+++ b/src/modules/Modules.h
@@ -4,3 +4,7 @@
  * Create module instances here.  If you are adding a new module, you must 'new' it here (or somewhere else)
  */
 void setupModules();
+
+// Forward declarations
+class AntennaInfoModule;
+extern AntennaInfoModule *antennaInfoModule;

--- a/src/serialization/MeshPacketSerializer.cpp
+++ b/src/serialization/MeshPacketSerializer.cpp
@@ -211,6 +211,26 @@ std::string MeshPacketSerializer::JsonSerialize(const meshtastic_MeshPacket *mp,
             }
             break;
         }
+        case meshtastic_PortNum_ANTENNA_INFO_APP: {
+            msgType = "antennainfo";
+            meshtastic_AntennaInfo scratch;
+            meshtastic_AntennaInfo *decoded = NULL;
+            memset(&scratch, 0, sizeof(scratch));
+            if (pb_decode_from_bytes(mp->decoded.payload.bytes, mp->decoded.payload.size, &meshtastic_AntennaInfo_msg,
+                                     &scratch)) {
+                decoded = &scratch;
+                msgPayload["node_id"] = new JSONValue((unsigned int)decoded->node_id);
+                msgPayload["height_m"] = new JSONValue((float)decoded->height_m);
+                msgPayload["azimuth_degrees"] = new JSONValue((unsigned int)decoded->azimuth_degrees);
+                msgPayload["orientation_degrees"] = new JSONValue((unsigned int)decoded->orientation_degrees);
+                msgPayload["eirp_dbm"] = new JSONValue((float)decoded->eirp_dbm);
+                msgPayload["last_updated"] = new JSONValue((unsigned int)decoded->last_updated);
+                jsonObj["payload"] = new JSONValue(msgPayload);
+            } else if (shouldLog) {
+                LOG_ERROR(errStr, msgType.c_str());
+            }
+            break;
+        }
         case meshtastic_PortNum_TRACEROUTE_APP: {
             if (mp->decoded.request_id) { // Only report the traceroute response
                 msgType = "traceroute";

--- a/src/serialization/MeshPacketSerializer_nRF52.cpp
+++ b/src/serialization/MeshPacketSerializer_nRF52.cpp
@@ -213,6 +213,26 @@ std::string MeshPacketSerializer::JsonSerialize(const meshtastic_MeshPacket *mp,
             }
             break;
         }
+        case meshtastic_PortNum_ANTENNA_INFO_APP: {
+            msgType = "antennainfo";
+            meshtastic_AntennaInfo scratch;
+            meshtastic_AntennaInfo *decoded = NULL;
+            memset(&scratch, 0, sizeof(scratch));
+            if (pb_decode_from_bytes(mp->decoded.payload.bytes, mp->decoded.payload.size, &meshtastic_AntennaInfo_msg,
+                                     &scratch)) {
+                decoded = &scratch;
+                jsonObj["payload"]["node_id"] = (unsigned int)decoded->node_id;
+                jsonObj["payload"]["height_m"] = (float)decoded->height_m;
+                jsonObj["payload"]["azimuth_degrees"] = (unsigned int)decoded->azimuth_degrees;
+                jsonObj["payload"]["orientation_degrees"] = (unsigned int)decoded->orientation_degrees;
+                jsonObj["payload"]["eirp_dbm"] = (float)decoded->eirp_dbm;
+                jsonObj["payload"]["last_updated"] = (unsigned int)decoded->last_updated;
+            } else if (shouldLog) {
+                LOG_ERROR("Error decoding proto for antennainfo message!");
+                return "";
+            }
+            break;
+        }
         case meshtastic_PortNum_TRACEROUTE_APP: {
             if (mp->decoded.request_id) { // Only report the traceroute response
                 msgType = "traceroute";


### PR DESCRIPTION
# Add AntennaInfo Module

This PR adds a new AntennaInfo module to the Meshtastic firmware that allows nodes to periodically broadcast antenna information across the mesh network.

## Features
- **Antenna Information Broadcasting**: Nodes can share antenna height, azimuth, orientation, and EIRP (Effective Isotropic Radiated Power) with other nodes in the mesh
- **Configurable Broadcast Intervals**: Users can set how often antenna information is broadcast (minimum 1 hour, default 4 hours)
- **LoRa Transmission Control**: Option to enable/disable LoRa transmission of antenna info packets
- **Configuration Persistence**: All settings are stored in the device configuration and persist across reboots

## Technical Details
- **Port Number**: Uses port 35 (`ANTENNA_INFO_APP`) for mesh communication
- **Message Format**: Protobuf-encoded `AntennaInfo` messages containing:
  - `node_id`: Source node identifier
  - `height_m`: Antenna height in meters above ground level
  - `azimuth_degrees`: Antenna azimuth in degrees (0-360, where 0 is North)
  - `orientation_degrees`: Antenna orientation (0=vertical, 90=horizontal, etc.)
  - `eirp_dbm`: Effective Isotropic Radiated Power in dBm
  - `last_updated`: Timestamp of last update

## Configuration
The module can be configured via the following settings:
- `enabled`: Enable/disable the module
- `update_interval`: Broadcast interval in seconds (minimum 3600s)
- `height_m`: Antenna height in meters
- `azimuth_degrees`: Antenna azimuth in degrees
- `orientation_degrees`: Antenna orientation in degrees
- `eirp_dbm`: EIRP in dBm
- `transmit_over_lora`: Whether to transmit over LoRa

## Build Integration
- Module can be excluded in firmware builds via `MESHTASTIC_EXCLUDE_ANTENNAINFO=1`
- Follows the same pattern as other optional modules like NeighborInfo

## Use Cases
- **Amateur Radio**: Share antenna setup information for propagation analysis
- **Network Planning**: Understand antenna configurations across the mesh
- **Technical Documentation**: Maintain records of antenna installations
- **Performance Analysis**: Correlate antenna parameters with link quality

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
